### PR TITLE
Cursor: add leader search keybindings

### DIFF
--- a/cursor/settings.json
+++ b/cursor/settings.json
@@ -85,8 +85,12 @@
 
         // search
         {
-            "before": ["<leader>", "s", "f"]
-            "commands": []
+            "before": ["<leader>", "s", "f"],
+            "commands": ["workbench.action.quickOpen"]
+        },
+        {
+            "before": ["<leader>", "s", "t"],
+            "commands": ["workbench.action.findInFiles"]
         }
-    ],
+    ]
 }


### PR DESCRIPTION
## Changes
- **`<leader>sf`** → quick open (same as Cmd+P)
- **`<leader>st`** → find in files (text search in repo)

Both live in `cursor/settings.json` under `vim.normalModeKeyBindingsNonRecursive` (leader is space).

Made with [Cursor](https://cursor.com)