### PR TITLE
Add notebook command-mode keybindings for tab navigation and undo

### DIFF
--- a/cursor/keybindings.json
+++ b/cursor/keybindings.json
@@ -4,6 +4,23 @@
         "command": "composerMode.agent"
     },
 
+    // notebook command mode tab navigation
+    {
+        "key": "shift+h",
+        "command": "workbench.action.previousEditorInGroup",
+        "when": "notebookEditorFocused && !inputFocus"
+    },
+    {
+        "key": "shift+l",
+        "command": "workbench.action.nextEditorInGroup",
+        "when": "notebookEditorFocused && !inputFocus"
+    },
+    {
+        "key": "u",
+        "command": "undo",
+        "when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused"
+    },
+
     // vim keybinds
     // movement
     {

--- a/cursor/settings.json
+++ b/cursor/settings.json
@@ -22,9 +22,8 @@
     "window.menuBarVisibility": "toggle",
     "breadcrumbs.enabled": false,
     "workbench.layoutControl.enabled": false,
-    "workbench.activityBar.visible": false,
     "workbench.activityBar.orientation": "vertical",
-    "workbench.activityBar.location": "bottom",
+    "workbench.activityBar.location": "hidden",
     "editor.minimap.enabled": false,
     "gitlens.currentLine.enabled": false,
 
@@ -92,5 +91,6 @@
             "before": ["<leader>", "s", "t"],
             "commands": ["workbench.action.findInFiles"]
         }
-    ]
+    ],
+    "notebook.lineNumbers": "on"
 }

--- a/vscode/keybindings.json
+++ b/vscode/keybindings.json
@@ -13,6 +13,21 @@
 		"when": "vim.active && vim.mode != 'Insert'"
 	},
 	{
+		"key": "shift+h",
+		"command": "workbench.action.previousEditorInGroup",
+		"when": "notebookEditorFocused && !inputFocus"
+	},
+	{
+		"key": "shift+l",
+		"command": "workbench.action.nextEditorInGroup",
+		"when": "notebookEditorFocused && !inputFocus"
+	},
+	{
+		"key": "u",
+		"command": "undo",
+		"when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused"
+	},
+	{
 		"key": "ctrl+k",
 		"command": "workbench.action.navigateUp",
 		"when": "vim.active && vim.mode != 'Insert'"


### PR DESCRIPTION
## Summary
- Add explicit notebook command-mode keybindings for `shift+h` and `shift+l` to move between open editor tabs outside Vim normal mode.
- Add notebook command-mode keybinding for `u` to run undo on the last notebook action.
- Mirror these bindings in both Cursor and VS Code keybinding files for consistent behavior.

## Problem
The existing `shift+h` / `shift+l` mappings were implemented through Vim normal-mode remaps, so they stopped working in notebook command mode while navigating cells (`j`/`k`).

## Solution
Define notebook-scoped keybindings (`notebookEditorFocused && !inputFocus`) in `cursor/keybindings.json` and `vscode/keybindings.json`, and add an undo binding for `u` in notebook command mode.

## Validation
- Verified manually in notebook command mode:
  - `shift+h` and `shift+l` switch tabs
  - `u` undoes the last notebook change