### PR TITLE
opencode: set default models for build and plan agents

### DIFF
--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -9,7 +9,7 @@
     },
     "plan": {
       "mode": "primary",
-      "model": "anthropic/claude-opus-4-5"
+      "model": "anthropic/claude-opus-4-6"
     }
   },
   "mcp": {

--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled",
+  "default_agent": "build",
+  "agent": {
+    "build": {
+      "mode": "primary",
+      "model": "openai/gpt-5.3-codex"
+    },
+    "plan": {
+      "mode": "primary",
+      "model": "anthropic/claude-opus-4-5"
+    }
+  },
+  "mcp": {
+    "bigquery": {
+      "type": "local",
+      "command": [
+        "/Users/chris/Documents/mcp_servers/mcp-toolbox/toolbox",
+        "--prebuilt",
+        "bigquery",
+        "--stdio"
+      ],
+      "enabled": true,
+      "environment": {
+        "BIGQUERY_PROJECT": "grafanalabs-global"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add project-level OpenCode configuration file at `opencode/opencode.jsonc`.
- Set `build` agent to `openai/gpt-5.3-codex` and `plan` agent to `anthropic/claude-opus-4-5`.
- Keep `build` as the default primary agent.

## Problem
The repository did not have a committed OpenCode config that pins model selection for primary agents, so planning and build workflows were not explicitly aligned with the intended defaults.

## Solution
- Commit `opencode/opencode.jsonc` with explicit primary agent configuration.
- Configure:
  - `agent.build.model = openai/gpt-5.3-codex`
  - `agent.plan.model = anthropic/claude-opus-4-5`
  - `default_agent = build`
- Preserve existing MCP BigQuery server settings in the same file.

## Test plan
- Not run (configuration-only change).