### PR TITLE
Add LLM tool aliases for quick CLI access

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -21,6 +21,11 @@ alias oops='git reset --soft HEAD^'
 alias python='python3'
 alias cclip='xclip -selection clipboard'
 
+# llm aliases
+alias cc='claude code'
+alias cx='codex'
+alias oc='opencode'
+
 # other aliases
 # alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
 alias t='sesh connect'


### PR DESCRIPTION
## Summary
- Adds convenient shell aliases for commonly used AI coding assistant tools
- Provides quick access to Claude Code, Codex, and OpenCode from the command line

## Changes
Added three new aliases to `zsh/aliases.zsh`:
- `cc` - shorthand for `claude code`
- `cx` - shorthand for `codex`
- `oc` - shorthand for `opencode`

## Rationale
These aliases streamline the workflow for accessing LLM-powered coding tools by reducing keystrokes and improving command-line ergonomics. Since these tools are frequently used during development, having short, memorable aliases improves productivity.