### PR TITLE
Add ai-kit sesh session configuration

### DIFF
--- a/sesh/sesh.toml
+++ b/sesh/sesh.toml
@@ -61,6 +61,11 @@ path = "~/projects/revops"
 startup_command = "tmux new-window -d && tmux new-window -d && nvim_cshih"
 
 [[session]]
+name = "ai-kit"
+path = "~/projects/ai-kit"
+startup_command = "tmux new-window -d && tmux new-window -d && nvim_cshih"
+
+[[session]]
 name = "projects"
 path = "~/projects"
 startup_command = "tmux new-window -d && tmux new-window -d && nvim_cshih"


### PR DESCRIPTION
## Summary
- Adds new ai-kit session configuration to sesh.toml for the ai-kit project

## Changes
- Added [[session]] block for ai-kit project
- Configured path to ~/projects/ai-kit
- Set startup command to open tmux with 2 additional windows and launch nvim

This follows the same pattern as existing project sessions (revops, kb-qtc) and enables quick access to the ai-kit project workspace via sesh.