### PR TITLE
Update Brewfile from current Homebrew installs

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -1,57 +1,128 @@
+tap "anomalyco/tap"
 tap "felixkratz/formulae"
 tap "grafana/grafana"
+tap "hashicorp/tap"
 tap "homebrew/services"
 tap "jesseduffield/lazygit"
 tap "joshmedeski/sesh"
 tap "nikitabobko/tap"
 tap "txn2/tap"
+# Official Amazon AWS command-line interface
 brew "awscli"
+# Memory upgrade for your coding agent
+brew "beads"
+# Resource monitor. C++ version and continuation of bashtop and bpytop
 brew "btop"
+# Isolated development environments using Docker
 brew "docker-compose"
+# Embeddable SQL OLAP Database Management System
+brew "duckdb"
+# Simple, fast and user-friendly alternative to find
 brew "fd"
+# Command-line fuzzy finder written in Go
 brew "fzf"
-brew "gifsicle"
-brew "gnupg"
-brew "go"
-brew "jq"
-brew "jsonnet"
-brew "kubernetes-cli"
-brew "lua"
-brew "lua-language-server"
-brew "neovim"
+# Open-source, cross-platform JavaScript runtime environment
 brew "node"
+# Interact with Google Gemini AI models from the command-line
+brew "gemini-cli"
+# GitHub command-line tool
+brew "gh"
+# GIF image/animation creator/editor
+brew "gifsicle"
+# GNU Privacy Guard (OpenPGP)
+brew "gnupg"
+# Open source programming language to build simple/reliable/efficient software
+brew "go"
+# Lightweight and flexible command-line JSON processor
+brew "jq"
+# Domain specific configuration language for defining JSON data
+brew "jsonnet"
+# Kubernetes command-line interface
+brew "kubernetes-cli"
+# Simple terminal UI for git commands
+brew "lazygit"
+# Powerful, lightweight programming language
+brew "lua"
+# Language Server for the Lua language
+brew "lua-language-server"
+# Incremental parsing library
+brew "tree-sitter"
+# Ambitious Vim-fork focused on extensibility and agility
+brew "neovim"
+# Pretty, minimal and fast ZSH prompt
 brew "pure"
+# Python version management
 brew "pyenv"
+# Search tool like grep and The Silver Searcher
 brew "ripgrep"
+# Terminal multiplexer
 brew "tmux"
+# Parser generator tool
+brew "tree-sitter-cli"
+# Extremely fast Python package installer and resolver, written in Rust
+brew "uv"
+# Internet file retriever
 brew "wget"
+# Process YAML, JSON, XML, CSV and properties documents from the CLI
 brew "yq"
+# Shell extension to navigate your filesystem faster
 brew "zoxide"
+# A window border system for macOS
 brew "felixkratz/formulae/borders"
+# Vendor-agnostic OpenTelemetry Collector distribution with programmable pipelines
 brew "grafana/grafana/alloy"
-brew "jesseduffield/lazygit/lazygit"
+# Terraform
+brew "hashicorp/tap/terraform"
+# Smart terminal session manager
 brew "joshmedeski/sesh/sesh"
+# Kubernetes bulk port forwarding utility.
 brew "txn2/tap/kubefwd"
+# Password manager that keeps all passwords secure behind one password
 cask "1password"
-cask "aerospace"
+# AeroSpace is an i3-like tiling window manager for macOS
+cask "nikitabobko/tap/aerospace"
+# GPU-accelerated terminal emulator
 cask "alacritty"
+# Open source IDE for exploring and testing APIs
 cask "bruno"
+# App to build and share containerised applications and microservices
 cask "docker-desktop"
+# Web browser
 cask "firefox"
 cask "font-hack-nerd-font"
+# Terminal emulator that uses platform-native UI and GPU acceleration
 cask "ghostty"
+# Web browser
 cask "google-chrome"
+# AI assistant for Grafana Cloud
+cask "grafana/grafana/grafana-assistant"
+# Shows the next meeting in the menu bar
 cask "meetingbar"
+# Open-source software for live streaming and screen recording
 cask "obs"
+# Knowledge base that works on top of a local folder of plain text Markdown files
 cask "obsidian"
+# Toolbox companion for QMK Firmware
 cask "qmk-toolbox"
+# Control your tools with a few keystrokes
 cask "raycast"
+# Team communication and collaboration software
 cask "slack"
+# Open-source code editor
 cask "visual-studio-code"
+# Multimedia player
 cask "vlc"
+# GPU-accelerated cross-platform terminal emulator and multiplexer
 cask "wezterm"
+# Multiplayer code editor
 cask "zed"
+# Gecko based web browser
 cask "zen"
+# Video communication and virtual meeting platform
 cask "zoom"
 vscode "catppuccin.catppuccin-vsc"
 vscode "vscodevim.vim"
+go "github.com/kitagry/bqls"
+go "golang.org/x/tools/gopls"
+uv "agent-starter-pack"
+uv "jupytext"


### PR DESCRIPTION
## Summary
- Regenerate `brew/Brewfile` from the currently installed Homebrew packages using `brew bundle dump --describe`
- Keep Homebrew-generated descriptive comments for taps, formulae, and casks to make the file easier to review
- Include newly installed taps, formulae, casks, and non-Homebrew package entries (`go` and `uv`)

## Test plan
- [x] Verify `brew/Brewfile` reflects current local installs
- [x] Confirm only `brew/Brewfile` changed in this PR