### PR TITLE
Add tree-sitter autocmds for Lua, Markdown, and Vim docs

### DIFF
--- a/nvim_cshih/lua/config/autocmds.lua
+++ b/nvim_cshih/lua/config/autocmds.lua
@@ -33,11 +33,24 @@ vim.api.nvim_create_autocmd("FileType", {
   end,
 })
 
--- lua, json
+-- lua
 vim.api.nvim_create_autocmd("FileType", {
-  group = augroup("ft_lua_json"),
-  pattern = { "lua", "json", "jsonc" },
-  callback = function()
+  group = augroup("ft_lua"),
+  pattern = { "lua" },
+  callback = function(ev)
+    vim.opt_local.shiftwidth = 2
+    vim.opt_local.softtabstop = 2
+    if ev.match == "lua" then
+      vim.treesitter.start(ev.buf, "lua")
+    end
+  end,
+})
+
+-- json
+vim.api.nvim_create_autocmd("FileType", {
+  group = augroup("ft_json"),
+  pattern = { "json", "jsonc" },
+  callback = function(ev)
     vim.opt_local.shiftwidth = 2
     vim.opt_local.softtabstop = 2
   end,
@@ -46,10 +59,33 @@ vim.api.nvim_create_autocmd("FileType", {
 -- markdown
 vim.api.nvim_create_autocmd("FileType", {
   group = augroup("ft_markdown"),
-  pattern = { "markdown" },
-  callback = function()
+  pattern = { "markdown", "markdown_inline" },
+  callback = function(ev)
     vim.opt_local.wrap = true
     vim.opt_local.linebreak = true
+    if ev.match == "markdown_inline" then
+      vim.treesitter.start(ev.buf, "markdown_inline")
+    else
+      vim.treesitter.start(ev.buf, "markdown")
+    end
+  end,
+})
+
+-- vimscript
+vim.api.nvim_create_autocmd("FileType", {
+  group = augroup("ft_vim"),
+  pattern = { "vim" },
+  callback = function(ev)
+    vim.treesitter.start(ev.buf, "vim")
+  end,
+})
+
+-- vim help docs
+vim.api.nvim_create_autocmd("FileType", {
+  group = augroup("ft_vimdoc"),
+  pattern = { "help" },
+  callback = function(ev)
+    vim.treesitter.start(ev.buf, "vimdoc")
   end,
 })
 


### PR DESCRIPTION
## Summary
- Enables built-in tree-sitter highlighting for Lua buffers in `nvim_cshih`.
- Enables tree-sitter startup for Markdown and Markdown inline parsing paths.
- Adds tree-sitter startup for Vimscript (`vim`) and help docs (`vimdoc`).

## Problem
After moving away from `nvim-treesitter`, only a subset of filetypes had explicit `vim.treesitter.start()` autocmds. Lua, Markdown, and Vim/Vimdoc were missing from the manual startup config.

## Solution
- Updated `nvim_cshih/lua/config/autocmds.lua` to start tree-sitter for:
  - `lua`
  - `markdown` / `markdown_inline`
  - `vim`
  - `help` (using `vimdoc` parser)
- Kept existing local editor options (like wrap/linebreak and indentation) intact.

## Test plan
- [x] Loaded updated autocmd file in headless Neovim to validate Lua syntax:
  - `nvim --headless -u NONE -c 'luafile /Users/chris/projects/dotfiles/nvim_cshih/lua/config/autocmds.lua' -c 'qa'`
- [x] Verified tree-sitter parser availability for targeted languages in local Neovim runtime.