### PR TITLE
Document available CLI tools and MCP servers

### DIFF
--- a/opencode/Agents.md
+++ b/opencode/Agents.md
@@ -1,2 +1,11 @@
 # Agents
-- When creating a GitHub branch or PR, always use the associated agent skill (create-git-branch, create-pull-request) instead of the GitHub CLI.
+- When creating a GitHub branch or PR, always use the associated agent skill (create-git-branch, create-pull-request) instead of the GitHub CLI directly.
+
+# Tools available
+## CLIs
+- gh: github cli. use to access anything related to github (i.e. reading repos, etc.)
+- gcx: grafana cli. use to access anything related to grafana cloud (i.e. dashboards, alerts, assistant investigations, etc.)
+
+## MCP Servers
+- airbud: internal knowledge base and data retriever. use to query bigquery, understand definitions, find the right bigquery tables, etc.
+- bigquery: should the airbud MCP server not be available, or providing errors, you can use the bigquery mcp server to find table metadata, execute queries, etc.


### PR DESCRIPTION
## Summary
- Added documentation for available CLI tools (gh, gcx) and MCP servers (airbud, bigquery) to opencode/Agents.md
- Provides clear context for when and how OpenCode should use these tools

## Problem
The Agents.md file previously only contained a single instruction about using agent skills instead of the GitHub CLI directly. It lacked documentation about which CLI tools and MCP servers are available in the environment and when they should be used.

This made it unclear to OpenCode:
- What tools are available for different tasks
- When to use specific tools (e.g., gh for GitHub operations, gcx for Grafana)
- Which MCP servers are available and what they provide access to

## Solution
Enhanced the Agents.md configuration file with two new sections:

1. **CLIs section**: Documents command-line tools with usage guidance
   - gh: GitHub CLI for repository and issue management
   - gcx: Grafana CLI for dashboards, alerts, and assistant investigations

2. **MCP Servers section**: Documents Model Context Protocol servers
   - airbud: Primary tool for BigQuery queries, knowledge base, and table discovery
   - bigquery: Fallback MCP server for BigQuery operations if airbud has issues

Each tool includes a brief description of when OpenCode should use it, providing clear context for autonomous decision-making.

## Impact
This change improves OpenCode's ability to:
- Automatically select the right tool for specific tasks
- Understand the full scope of available infrastructure
- Make informed decisions about which MCP server to use for data operations