### PR TITLE
Add NVM configuration to zshrc

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -46,3 +46,8 @@ command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
 PATH=$(pyenv root)/shims:$PATH
+
+# NVM
+export NVM_DIR="$HOME/.nvm"
+[ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"
+[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"


### PR DESCRIPTION
## Summary
- Add NVM (Node Version Manager) configuration to zshrc
- Enable NVM functionality with Homebrew-installed nvm
- Include bash completion for better developer experience

## Problem
NVM was not configured in the zsh environment, making it difficult to manage multiple Node.js versions. The Homebrew installation of NVM requires specific shell configuration to function properly.

## Solution
Added a dedicated NVM configuration block to `zsh/.zshrc` that:
- Exports `NVM_DIR` environment variable pointing to `~/.nvm`
- Sources the nvm.sh script from Homebrew installation path (`/opt/homebrew/opt/nvm/nvm.sh`)
- Sources bash completion script for enhanced command-line tab completion

This follows the standard Homebrew NVM setup pattern and ensures NVM commands are available in all interactive zsh sessions.

## Test plan
- [x] Verified NVM installation paths exist (`/opt/homebrew/opt/nvm/nvm.sh`)
- [x] Confirmed NVM loads in fresh interactive zsh session (`nvm --version` → `0.40.4`)
- [x] Verified `NVM_DIR` environment variable is set correctly
- [x] Tested `nvm ls` command functions properly