### PR TITLE
Add bizops sesh session

### DIFF
--- a/sesh/sesh.toml
+++ b/sesh/sesh.toml
@@ -11,6 +11,11 @@ path = "~/projects/bizo11y"
 startup_command = "tmux new-window -d && tmux new-window -d && tmux new-window -d && nvim_cshih"
 
 [[session]]
+name = "bizops"
+path = "~/projects/bizops"
+startup_command = "tmux new-window -d && tmux new-window -d && tmux new-window -d && nvim_cshih"
+
+[[session]]
 name = "oss-data-stack"
 path = "~/projects/oss-data-stack"
 startup_command = "tmux new-window -d && tmux new-window -d && tmux new-window -d && nvim_cshih"


### PR DESCRIPTION
## Summary
- Adds a new `bizops` session entry to the sesh session manager configuration

## Problem
The `bizops` project did not have a dedicated sesh session, requiring manual setup each time a new tmux session was needed for that project.

## Solution
- Added a new `[[session]]` block in `sesh/sesh.toml` for the `bizops` project
- Configured it to open at `~/projects/bizops` with the standard startup command (3 extra windows + neovim), consistent with other project sessions like `bizo11y`

## Test plan
- [x] Verified the TOML syntax is valid and consistent with existing session entries