### PR TITLE
nvim_cshih: Go LSP setup (gopls, treesitter, format-on-save)

### DIFF
--- a/nvim_cshih/lazy-lock.json
+++ b/nvim_cshih/lazy-lock.json
@@ -2,16 +2,8 @@
   "blink.cmp": { "branch": "main", "commit": "78336bc89ee5365633bcf754d93df01678b5c08f" },
   "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
   "catppuccin": { "branch": "main", "commit": "426dbebe06b5c69fd846ceb17b42e12f890aedf1" },
-<<<<<<< Updated upstream
-  "fzf-lua": { "branch": "main", "commit": "2e29d5f233defe3c5587df0e4dd29af2bd95a5a7" },
-=======
-<<<<<<< Updated upstream
-  "fzf-lua": { "branch": "main", "commit": "ffa44ee9470743a7697d28df3a1a216fdfe2b09d" },
-=======
-  "fzf-lua": { "branch": "main", "commit": "b437bafc981a180d609bb4092c56ce8999f7a2c4" },
->>>>>>> Stashed changes
->>>>>>> Stashed changes
-  "gitsigns.nvim": { "branch": "main", "commit": "6d808f99bd63303646794406e270bd553ad7792e" },
+  "fzf-lua": { "branch": "main", "commit": "10c19a5f08bfeed34b930a1efddda3a9a983e6e2" },
+  "gitsigns.nvim": { "branch": "main", "commit": "dd3f588bacbeb041be6facf1742e42097f62165d" },
   "indent-blankline.nvim": { "branch": "master", "commit": "d28a3f70721c79e3c5f6693057ae929f3d9c0a03" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "lazydev.nvim": { "branch": "main", "commit": "ff2cbcba459b637ec3fd165a2be59b7bbaeedf0d" },

--- a/nvim_cshih/lsp/gopls.lua
+++ b/nvim_cshih/lsp/gopls.lua
@@ -4,6 +4,24 @@ return {
   filetypes = { "go", "gomod", "gowork", "gotmpl" },
   root_markers = { "go.mod", "go.work", ".git" },
   settings = {
+    gopls = {
+      gofumpt = true,
+      staticcheck = true,
+      analyses = {
+        nilness = true,
+        shadow = true,
+        unusedparams = true,
+        unusedwrite = true,
+      },
+      hints = {
+        assignVariableTypes = true,
+        compositeLiteralFields = true,
+        compositeLiteralTypes = true,
+        constantValues = true,
+        functionTypeParameters = true,
+        parameterNames = true,
+        rangeVariableTypes = true,
+      },
+    },
   }
 }
-

--- a/nvim_cshih/lua/config/autocmds.lua
+++ b/nvim_cshih/lua/config/autocmds.lua
@@ -2,6 +2,30 @@ local function augroup(name)
   return vim.api.nvim_create_augroup("cshih_" .. name, { clear = true })
 end
 
+local function organize_go_imports(bufnr)
+  local clients = vim.lsp.get_clients({ bufnr = bufnr, name = "gopls" })
+  if #clients == 0 then
+    return
+  end
+
+  local params = vim.lsp.util.make_range_params(0, clients[1].offset_encoding)
+  params.textDocument = vim.lsp.util.make_text_document_params(bufnr)
+  params.context = { only = { "source.organizeImports" }, diagnostics = {} }
+
+  local results = vim.lsp.buf_request_sync(bufnr, "textDocument/codeAction", params, 1000)
+  for client_id, result in pairs(results or {}) do
+    local client = vim.lsp.get_client_by_id(client_id)
+    for _, action in pairs(result.result or {}) do
+      if action.edit and client then
+        vim.lsp.util.apply_workspace_edit(action.edit, client.offset_encoding)
+      end
+      if action.command then
+        vim.lsp.buf.execute_command(action.command)
+      end
+    end
+  end
+end
+
 -- sql
 vim.api.nvim_create_autocmd("FileType", {
   group = augroup("ft_sql"),
@@ -21,6 +45,34 @@ vim.api.nvim_create_autocmd("FileType", {
     vim.opt_local.shiftwidth = 4
     vim.opt_local.softtabstop = 4
     vim.treesitter.start(ev.buf, "python")
+  end,
+})
+
+-- go
+vim.api.nvim_create_autocmd("FileType", {
+  group = augroup("ft_go"),
+  pattern = { "go" },
+  callback = function(ev)
+    vim.opt_local.expandtab = false
+    vim.opt_local.tabstop = 4
+    vim.opt_local.shiftwidth = 4
+    vim.opt_local.softtabstop = 0
+    vim.treesitter.start(ev.buf, "go")
+  end,
+})
+
+vim.api.nvim_create_autocmd("BufWritePre", {
+  group = augroup("fmt_go"),
+  pattern = { "*.go" },
+  callback = function(ev)
+    organize_go_imports(ev.buf)
+    vim.lsp.buf.format({
+      bufnr = ev.buf,
+      timeout_ms = 3000,
+      filter = function(client)
+        return client.name == "gopls"
+      end,
+    })
   end,
 })
 

--- a/nvim_cshih/queries/go/highlights.scm
+++ b/nvim_cshih/queries/go/highlights.scm
@@ -1,0 +1,123 @@
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (identifier) @function.builtin
+  (#match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @function.method))
+
+; Function definitions
+
+(function_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  name: (field_identifier) @function.method)
+
+; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
+; Operators
+
+[
+  "--"
+  "-"
+  "-="
+  ":="
+  "!"
+  "!="
+  "..."
+  "*"
+  "*"
+  "*="
+  "/"
+  "/="
+  "&"
+  "&&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "^="
+  "+"
+  "++"
+  "+="
+  "<-"
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "|"
+  "|="
+  "||"
+  "~"
+] @operator
+
+; Keywords
+
+[
+  "break"
+  "case"
+  "chan"
+  "const"
+  "continue"
+  "default"
+  "defer"
+  "else"
+  "fallthrough"
+  "for"
+  "func"
+  "go"
+  "goto"
+  "if"
+  "import"
+  "interface"
+  "map"
+  "package"
+  "range"
+  "return"
+  "select"
+  "struct"
+  "switch"
+  "type"
+  "var"
+] @keyword
+
+; Literals
+
+[
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (rune_literal)
+] @string
+
+(escape_sequence) @escape
+
+[
+  (int_literal)
+  (float_literal)
+  (imaginary_literal)
+] @number
+
+[
+  (true)
+  (false)
+  (nil)
+  (iota)
+] @constant.builtin
+
+(comment) @comment

--- a/nvim_cshih/queries/go/tags.scm
+++ b/nvim_cshih/queries/go/tags.scm
@@ -1,0 +1,42 @@
+(
+  (comment)* @doc
+  .
+  (function_declaration
+    name: (identifier) @name) @definition.function
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (method_declaration
+    name: (field_identifier) @name) @definition.method
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.method)
+)
+
+(call_expression
+  function: [
+    (identifier) @name
+    (parenthesized_expression (identifier) @name)
+    (selector_expression field: (field_identifier) @name)
+    (parenthesized_expression (selector_expression field: (field_identifier) @name))
+  ]) @reference.call
+
+(type_spec
+  name: (type_identifier) @name) @definition.type
+
+(type_identifier) @name @reference.type
+
+(package_clause "package" (package_identifier) @name)
+
+(type_declaration (type_spec name: (type_identifier) @name type: (interface_type)))
+
+(type_declaration (type_spec name: (type_identifier) @name type: (struct_type)))
+
+(import_declaration (import_spec) @name)
+
+(var_declaration (var_spec name: (identifier) @name))
+
+(const_declaration (const_spec name: (identifier) @name))


### PR DESCRIPTION
## Summary
- Configures gopls with sensible settings (gofumpt, staticcheck, analyses, inlay hints)
- Adds Go treesitter parser queries (highlights, tags) for syntax highlighting
- Adds Go filetype autocmd (tab indentation, treesitter start) and format-on-save via gopls

## Problem
The `nvim_cshih` config had `gopls` enabled in `lua/core/lsp.lua` and a stub `lsp/gopls.lua` but with empty settings — no formatting, no treesitter highlighting, and no Go-specific filetype options. The Go treesitter parser (`.so`) was also missing, and no queries existed for it.

## Research & Context
- Confirmed gopls was at v0.19.1 (latest is v0.21.1) — updated externally via `go install`
- Confirmed no Go treesitter parser or queries were present in the nvim_cshih data/config directories
- Config uses Neovim 0.11+ native LSP (`vim.lsp.enable()`) — no nvim-lspconfig or mason needed
- Existing filetype autocmd pattern (sql, python, yaml, lua) was followed for Go

## Changes

### `nvim_cshih/lsp/gopls.lua`
- Added `gofumpt = true` for stricter formatting
- Added `staticcheck = true` for extra static analysis
- Enabled analyses: `nilness`, `shadow`, `unusedparams`, `unusedwrite`
- Enabled inlay hints: parameter names, variable types, composite literal fields/types, constant values, function type parameters, range variable types

### `nvim_cshih/queries/go/`
- Added `highlights.scm` (syntax highlighting) sourced from tree-sitter-go
- Added `tags.scm` (symbol tagging for navigation) sourced from tree-sitter-go
- Matches the existing pattern used for `queries/python/`, `queries/sql/`, `queries/yaml/`

### `nvim_cshih/lua/config/autocmds.lua`
- Added `FileType go` autocmd: `expandtab=false`, `tabstop=4`, `shiftwidth=4`, starts treesitter
- Added `BufWritePre *.go` autocmd: organizes imports via `source.organizeImports` code action, then formats via `vim.lsp.buf.format()` — all through gopls, no extra plugins

### `nvim_cshih/lazy-lock.json`
- Resolved pre-existing merge conflict, bumped fzf-lua and gitsigns.nvim commit hashes

## Test Plan
- [x] Verified gopls v0.21.1 is on PATH
- [x] Verified Go treesitter parser (`go.so`) loads successfully in headless Neovim
- [x] Verified `highlights` and `tags` queries load via `vim.treesitter.query.get`
- [x] Verified full `nvim_cshih` config loads headlessly without errors
- [x] Verified Go filetype autocmd applies correct options (`expandtab=false`, `tabstop=4`, `shiftwidth=4`) when opening a `.go` file
- [x] Verified `BufWritePre` autocmd runs without error when no LSP is attached