### PR TITLE
Restore confirm-before prompt when killing tmux pane

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -8,7 +8,7 @@ bind - split-window -v -c "#{pane_current_path}"
 unbind '"'
 unbind %
 
-bind x kill-pane
+bind x confirm-before -p "kill-pane #P? (y/n)" kill-pane
 bind C-k display-popup -E -w 50% "sesh connect \"$(sesh list -c | fzf --gutter ' ' --highlight-line)\""
 bind C-l send-keys 'C-l'
 bind r source-file ~/.config/tmux/tmux.conf


### PR DESCRIPTION
## Summary
- Restores the confirmation prompt before killing a tmux pane with `prefix + x`
- Fixes `~/.config/tmux/tmux.conf` being a regular file instead of a symlink to the dotfiles repo

## Problem
The `bind x kill-pane` binding in `tmux/tmux.conf` was overriding tmux's default behavior, which normally wraps `kill-pane` with `confirm-before` to prompt `kill-pane #P? (y/n)` before destroying a pane. This meant pressing `prefix + x` would immediately kill the pane with no warning.

Additionally, `~/.config/tmux/tmux.conf` was a standalone regular file rather than a symlink to the dotfiles repo, meaning edits to the repo were not reflected in the live tmux config (and vice versa).

## Changes
- `tmux/tmux.conf`: Changed `bind x kill-pane` to `bind x confirm-before -p "kill-pane #P? (y/n)" kill-pane`
- Replaced `~/.config/tmux/tmux.conf` with a symlink pointing to `/Users/chris/projects/dotfiles/tmux/tmux.conf`

## Test plan
- [x] Verified live tmux binding with `tmux list-keys -T prefix` confirms `confirm-before` is active for both `x` (kill-pane) and `&` (kill-window)
- [x] Confirmed symlink is in place: `~/.config/tmux/tmux.conf -> /Users/chris/projects/dotfiles/tmux/tmux.conf`
- [x] Reloaded config with `prefix + r` and verified bindings updated correctly