### PR TITLE
fix(opencode): migrate keybinds to keymap format, fix ctrl+d cancelling plan-mode questions

### DIFF
--- a/opencode/tui.jsonc
+++ b/opencode/tui.jsonc
@@ -1,13 +1,26 @@
 {
   "$schema": "https://opencode.ai/tui.json",
   "theme": "catppuccin-macchiato-transparent",
-  // "alternate_screen": false,
   "scroll_speed": 3,
-  "keybinds": {
+  "keymap": {
     "leader": "ctrl+o",
-    "messages_page_up": "ctrl+u",
-    "messages_page_down": "ctrl+d",
-    "input_delete_to_line_end": "none"
+    "sections": {
+      "global": {
+        "app.exit": "ctrl+c,<leader>q"
+      },
+      "session": {
+        "session.half.page.up": "ctrl+u,ctrl+alt+u",
+        "session.half.page.down": "ctrl+d,ctrl+alt+d"
+      },
+      "input": {
+        "input.delete": "delete,shift+delete",
+        "input.delete.to.line.end": "none",
+        "input.delete.to.line.start": "none"
+      },
+      "question": {
+        "question.reject": "ctrl+c,<leader>q"
+      }
+    }
   },
   "scroll_acceleration": {
     "enabled": true


### PR DESCRIPTION
## Summary
- Migrates `opencode/tui.jsonc` from the deprecated `keybinds` format to the new `keymap` format
- Fixes `ctrl+d` unintentionally cancelling plan-mode questions when used to scroll down in the chat

## Problem
`ctrl+d` was bound to `messages_page_down` via the legacy `keybinds` field, but it was also the default binding for several other actions in the new keymap system:
- `question.reject` — cancels plan-mode questions
- `app.exit` — exits the app
- `input.delete` — deletes the character under the cursor

When a plan-mode question prompt was active and the user pressed `ctrl+d` to scroll down, the `question.reject` binding fired first, dismissing the question.

## Solution
Migrated to the `keymap` format and explicitly removed `ctrl+d` from all conflicting bindings:
- `question.reject`: now only `ctrl+c,<leader>q`
- `app.exit`: now only `ctrl+c,<leader>q`
- `input.delete`: now only `delete,shift+delete`
- `input.delete.to.line.start`: set to `none` (removes default `ctrl+u`, which is used for scroll up)
- `input.delete.to.line.end`: kept as `none` (preserving existing preference)

`ctrl+u` and `ctrl+d` are now exclusively bound to `session.half.page.up` and `session.half.page.down` respectively.

## Test plan
- [ ] Open a session in plan mode, scroll up with `ctrl+u`, then scroll back down with `ctrl+d` — questions should remain active
- [ ] Verify `ctrl+c` still cancels questions and exits the app
- [ ] Verify `<leader>q` (`ctrl+o q`) still exits the app