### PR TITLE
update create-pull-request skill: add FORBIDDEN rule, remove auto-commit step

### DIFF
--- a/opencode/skills/create-pull-request/SKILL.md
+++ b/opencode/skills/create-pull-request/SKILL.md
@@ -6,6 +6,9 @@ description: Create a github pull request
 # Intent
 Create a github pull request, using the github cli (gh), that describes the changes made on the current git branch, unless a specific branch is specified.
 
+# FORBIDDEN
+NEVER commit code - if there is uncommitted code relevant to the PR, ask me if I would like to commit it before continuing.
+
 # Step-by-Step Instructions
 The following will be a step-by-step set of things to check. Each step is important to follow and will typically be needed for a successful PR to be created.
 
@@ -13,12 +16,9 @@ The following will be a step-by-step set of things to check. Each step is import
 The first thing to do is understand the changes that have been made. Unless otherwise specified in the initial prompt, you can assume that the current branch checked out is the one that contains the work that has been done.
 
 ## Step 2: Understand the intent of the branch
-The next thing is to understand the intent of the branch. This typically comes from a combination of the changes made, the name of the branch, and additional context from previous agent discussion (i.e. when creating a branch via an agent, the intent is typically discussed)
+The next thing is to understand the intent of the branch. This typically comes from a combination of the changes made, reading the commit messages (you can use the gh cli to do so), the name of the branch, and additional context from previous agent discussion (i.e. when creating a branch via an agent, the intent is typically discussed)
 
-## Step 3: Commit the changes that are related to the branch's intent
-Once the intent and changes have been understood, we then want to commit the changes in logical chunks in order to make it easier for a reviewer to understand what work has been done. You can use the github cli (gh) to make these commits.
-
-## Step 4: Push the branch and create a PR
+## Step 3: Push the branch and create a PR
 Lastly, once the changes have been committed, we need to push the branch and create a PR. When creating the PR we should aim to be concise but thorough to provide the reviewer with an overview of:
 
 1. the problem we intend to solve


### PR DESCRIPTION
## Summary
- Adds a `FORBIDDEN` rule to the `create-pull-request` skill explicitly preventing it from committing code autonomously
- Removes the \"Step 3: Commit the changes\" step from the skill workflow
- Updates Step 2 to include reading commit messages (via `gh` CLI) as a source of branch intent

## Problem
The `create-pull-request` skill previously included a step that instructed the agent to commit changes as part of the PR creation workflow. This is undesirable because:
- Commits should be a deliberate, user-controlled action
- The agent should not silently bundle and commit changes without explicit user consent
- Auto-committing can result in poorly scoped or unintentional commits

## Solution
- Added a `FORBIDDEN` section near the top of the skill that explicitly prohibits committing code, and instructs the agent to ask the user before proceeding if there is uncommitted code
- Removed Step 3 (\"Commit the changes that are related to the branch's intent\") entirely
- Renumbered Step 4 → Step 3
- Added mention of reading commit messages as a way to understand branch intent in Step 2

## Test plan
- [x] Verified the skill loads correctly and the FORBIDDEN rule is prominent
- [x] Confirmed the workflow no longer includes an auto-commit step