### PR TITLE
Disable Ctrl-D in zsh to prevent accidental tmux pane/window closure

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -47,6 +47,10 @@ eval "$(pyenv init -)"
 alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
 PATH=$(pyenv root)/shims:$PATH
 
+# Prevent Ctrl-D from closing the shell or triggering completion
+setopt IGNORE_EOF
+bindkey -r '^D'
+
 # NVM
 export NVM_DIR="$HOME/.nvm"
 [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"


### PR DESCRIPTION
## Summary
- Disables Ctrl-D in zsh to prevent it from closing the shell (and by extension, tmux panes/windows)
- Also unbinds Ctrl-D from zsh's completion widget to prevent it from triggering large completion lists

## Problem
Pressing Ctrl-D in a tmux pane sends EOF to the shell, which immediately exits and closes the pane/window without any confirmation. This is easy to trigger accidentally and disruptive when working in tmux.

Additionally, with `IGNORE_EOF` alone, pressing Ctrl-D falls through to zsh's completion system, which triggers a massive completion list prompt (e.g., "do you wish to see all 3570 possibilities?").

## Solution
Added two lines to `.zshrc`:
- `setopt IGNORE_EOF` — prevents Ctrl-D from sending EOF to zsh, so the shell no longer exits on Ctrl-D
- `bindkey -r '^D'` — unbinds Ctrl-D from zsh's line editor entirely, preventing it from triggering the completion widget

## Test plan
- [x] Verify Ctrl-D no longer closes the shell/tmux pane
- [x] Verify Ctrl-D no longer triggers completion list prompt
- [x] Verify `exit` command still works to close the shell normally